### PR TITLE
feat(storage): cấu hình tải dữ liệu lên S3

### DIFF
--- a/src/main/java/edu/cfd/e_learningPlatform/config/S3Config.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/config/S3Config.java
@@ -1,0 +1,30 @@
+package edu.cfd.e_learningPlatform.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${s3.accessKey}")
+    private String accessKey;
+
+    @Value("${s3.secretKey}")
+    private String secretKey;
+
+    @Value("${s3.region}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/edu/cfd/e_learningPlatform/controller/UploadS3.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/controller/UploadS3.java
@@ -1,0 +1,36 @@
+package edu.cfd.e_learningPlatform.controller;
+
+import edu.cfd.e_learningPlatform.dto.request.UploadImageRequest;
+import edu.cfd.e_learningPlatform.dto.response.ApiResponse;
+import edu.cfd.e_learningPlatform.dto.response.UploadImageResponse;
+import edu.cfd.e_learningPlatform.service.S3Service;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/s3/upload")
+public class UploadS3 {
+    private final S3Service s3Service;
+
+    public UploadS3(S3Service s3Service) {
+        this.s3Service = s3Service;
+    }
+
+    @PostMapping("/image")
+    public ApiResponse<UploadImageResponse> uploadImages(@RequestParam("img") MultipartFile image) throws IOException {
+        String urlImg = s3Service.uploadImage(image);
+        UploadImageResponse result = UploadImageResponse.builder()
+                .urlImg(urlImg)
+                .build();
+
+        return ApiResponse.<UploadImageResponse>builder()
+                .result(result)
+                .message("Image uploaded successfully")
+                .build();
+    }
+}

--- a/src/main/java/edu/cfd/e_learningPlatform/dto/request/UploadImageRequest.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/dto/request/UploadImageRequest.java
@@ -1,0 +1,14 @@
+package edu.cfd.e_learningPlatform.dto.request;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UploadImageRequest {
+    MultipartFile img;
+}

--- a/src/main/java/edu/cfd/e_learningPlatform/dto/response/UploadImageResponse.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/dto/response/UploadImageResponse.java
@@ -1,0 +1,13 @@
+package edu.cfd.e_learningPlatform.dto.response;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UploadImageResponse {
+    String urlImg;
+}

--- a/src/main/java/edu/cfd/e_learningPlatform/service/Impl/S3ServiceImpl.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/service/Impl/S3ServiceImpl.java
@@ -1,0 +1,31 @@
+package edu.cfd.e_learningPlatform.service.Impl;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+public class S3ServiceImpl implements edu.cfd.e_learningPlatform.service.S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${s3.bucketName}")
+    private String BUCKET_NAME;
+
+    public S3ServiceImpl(AmazonS3 amazonS3) {
+        this.amazonS3 = amazonS3;
+    }
+
+    @Override
+    public String uploadImage(MultipartFile file) throws IOException {
+        String fileName = file.getOriginalFilename();
+        PutObjectRequest putRequest = new PutObjectRequest(BUCKET_NAME, fileName, file.getInputStream(), new ObjectMetadata());
+        amazonS3.putObject(putRequest);
+        return "https://" + BUCKET_NAME + ".s3.amazonaws.com/" + fileName;
+    }
+
+}

--- a/src/main/java/edu/cfd/e_learningPlatform/service/S3Service.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/service/S3Service.java
@@ -1,0 +1,10 @@
+package edu.cfd.e_learningPlatform.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface S3Service {
+    String uploadImage(MultipartFile file) throws IOException;
+    }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 spring.application.name=e-learningPlatform
-
 # JPA properties
 spring.datasource.url=jdbc:mysql://localhost:3306/CourseForDevelopment
 spring.datasource.username=root
@@ -8,8 +7,13 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-
-
+spring.servlet.multipart.max-file-size=1GB
+spring.servlet.multipart.max-request-size=1GB
+# AWS S3 properties
+s3.accessKey=
+s3.secretKey=
+s3.region=
+s3.bucketName=
 #mail
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
@@ -17,5 +21,4 @@ spring.mail.username=sangpray3@gmail.com
 spring.mail.password=qjspufamvsvikyxw
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
-
 jwt.signerKey=1TjXchw5FloESb63Kc+DFhTARvpWL4jUGCwfGWxuG5SIf/1y/LgJxHnMqaF6A/ij


### PR DESCRIPTION
Thêm và cấu hình API để tải dữ liệu lên Amazon S3 trong hệ thống e-learning.
- Cài đặt và cấu hình thư viện AWS SDK cho Java
- Tạo API endpoint để tải ảnh lên S3
- Cấu hình quyền truy cập và bảo mật cho S3 bucket
- Thêm xử lý lỗi và thông báo khi tải tệp thành công hoặc thất bại