### PR TITLE
feat(api): thêm endpoint đăng ký người dùng

### DIFF
--- a/src/main/java/edu/cfd/e_learningPlatform/config/ApplicationInitConfig.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/config/ApplicationInitConfig.java
@@ -58,8 +58,8 @@ public class ApplicationInitConfig {
                 User user = User.builder()
                         .username("admin")
                         .password(passwordEncoder.encode("admin"))
-                        .email("user@example.com")
-                        .fullname("John Doe")
+                        .email("khanhtdps36301@fpt.edu.vn")
+                        .fullname("khanhtd36301")
                         .birthday(new Date())
                         .gender(Gender.MALE)
                         .phone("123456789")
@@ -69,8 +69,6 @@ public class ApplicationInitConfig {
                         .updatedDate(LocalDateTime.now())
                         .isActive(true)
                         .build();
-
-
                 userRepository.save(user);
                 log.warn("Admin user has been created with default password: admin, please change it.");
             }

--- a/src/main/java/edu/cfd/e_learningPlatform/controller/AuthenticationController.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/controller/AuthenticationController.java
@@ -44,38 +44,4 @@ public class AuthenticationController {
                 .build();
     }
 
-    @PostMapping("/forgot-password")
-    ApiResponse<EmailResponse> forgotPassword(@RequestBody EmailRequest request) throws MessagingException {
-        String otp = emailService.generateOTP(request.getEmail());
-        emailService.sendOTPEmail(request.getEmail(), otp);
-        return ApiResponse.<EmailResponse>builder()
-                .result(EmailResponse.builder()
-                        .hashedOtp( passwordEncoder.encode(otp))
-                        .creationTime(LocalDateTime.now())
-                        .build())
-                .build();
-    }
-
-    @PostMapping("/verify-otp")
-    public ApiResponse<VerifyOtpResponse> verifyOtp(@RequestBody VerifyOtpRequest request) {
-        LocalDateTime expirationTime = LocalDateTime.now();
-        boolean isOtpValid = emailService.verifyOTP(request.getOtp(), request.getHashedOtp(), request.getCreationTime(), expirationTime);
-        return ApiResponse.<VerifyOtpResponse>builder()
-                .result(VerifyOtpResponse.builder()
-                        .valid(isOtpValid)
-                        .build())
-                .build();
-    }
-
-    @PostMapping("/send-email-creation-user")
-    ApiResponse<EmailResponse> creationUser(@RequestBody EmailRequest request) throws MessagingException {
-        String otp = emailService.generateOTP(request.getEmail());
-        emailService.sendOTPEmailForCreationUser(request.getEmail(),request.getUsername(), otp);
-        return ApiResponse.<EmailResponse>builder()
-                .result(EmailResponse.builder()
-                        .hashedOtp( passwordEncoder.encode(otp))
-                        .creationTime(LocalDateTime.now())
-                        .build())
-                .build();
-    }
 }

--- a/src/main/java/edu/cfd/e_learningPlatform/controller/UserController.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/controller/UserController.java
@@ -1,0 +1,37 @@
+package edu.cfd.e_learningPlatform.controller;
+
+import edu.cfd.e_learningPlatform.dto.request.UpdatePassWordRequest;
+import edu.cfd.e_learningPlatform.dto.request.UserCreationRequest;
+import edu.cfd.e_learningPlatform.dto.request.UserUpdateRequest;
+import edu.cfd.e_learningPlatform.dto.response.ApiResponse;
+import edu.cfd.e_learningPlatform.dto.response.UpdatePassWordResponse;
+import edu.cfd.e_learningPlatform.dto.response.UserResponse;
+import edu.cfd.e_learningPlatform.service.UserService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Slf4j
+@CrossOrigin("*")
+public class UserController {
+    UserService userService;
+    PasswordEncoder passwordEncoder;
+
+    @PostMapping()
+    ApiResponse<UserResponse> createUser(@RequestBody UserCreationRequest request) {
+        return ApiResponse.<UserResponse>builder()
+                .result(userService.createUser(request))
+                .build();
+    }
+
+}

--- a/src/main/java/edu/cfd/e_learningPlatform/service/Impl/UserServiceImpl.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/service/Impl/UserServiceImpl.java
@@ -72,7 +72,8 @@ public class UserServiceImpl implements UserService {
 
         userMapper.updateUser(user, request);
         user.setPassword(passwordEncoder.encode(request.getPassword()));
-
+        LocalDateTime now = LocalDateTime.now();
+        user.setUpdatedDate(now);
         return userMapper.toUserResponse(userRepository.save(user));
     }
 


### PR DESCRIPTION
Thêm API endpoint để người dùng đăng ký tài khoản trong hệ thống e-learning.
- Tạo endpoint POST /users/
- Thêm validation cho các trường: username, password, email
- Lưu thông tin người dùng mới vào cơ sở dữ liệu
- Trả về phản hồi xác nhận đăng ký thành công hoặc thông báo lỗi