### PR TITLE
feat(auth): thêm tính năng lấy lại tài khoản qua email

### DIFF
--- a/src/main/java/edu/cfd/e_learningPlatform/controller/AuthenticationController.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/controller/AuthenticationController.java
@@ -44,4 +44,28 @@ public class AuthenticationController {
                 .build();
     }
 
+    @PostMapping("/forgot-password")
+    ApiResponse<EmailResponse> forgotPassword(@RequestBody EmailRequest request) throws MessagingException {
+        String otp = emailService.generateOTP(request.getEmail());
+        emailService.sendOTPEmail(request.getEmail(), otp);
+        return ApiResponse.<EmailResponse>builder()
+                .result(EmailResponse.builder()
+                        .hashedOtp(passwordEncoder.encode(otp))
+                        .creationTime(LocalDateTime.now())
+                        .build())
+                .build();
+    }
+
+    @PostMapping("/verify-otp")
+    public ApiResponse<VerifyOtpResponse> verifyOtp(@RequestBody VerifyOtpRequest request) {
+        LocalDateTime expirationTime = LocalDateTime.now();
+        boolean isOtpValid = emailService.verifyOTP(request.getOtp(), request.getHashedOtp(), request.getCreationTime(), expirationTime);
+        return ApiResponse.<VerifyOtpResponse>builder()
+                .result(VerifyOtpResponse.builder()
+                        .valid(isOtpValid)
+                        .build())
+                .build();
+    }
+
+
 }


### PR DESCRIPTION
Thêm API endpoint để người dùng có thể lấy lại tài khoản qua email trong hệ thống e-learning.
- Tạo endpoint POST /authentication/forgot-password để nhận yêu cầu giửi mã lấy lại tài khoản
- Tạo endpoint POST /authentication/verify-otp để xác thực người dùng
- Thêm xử lý lỗi và phản hồi khi yêu cầu lấy lại tài khoản thành công/thất bại