### PR TITLE
hotfix(registration): bổ sung API xác thực người dùng khi đăng ký

### DIFF
--- a/src/main/java/edu/cfd/e_learningPlatform/controller/AuthenticationController.java
+++ b/src/main/java/edu/cfd/e_learningPlatform/controller/AuthenticationController.java
@@ -44,4 +44,16 @@ public class AuthenticationController {
                 .build();
     }
 
+    @PostMapping("/send-email-creation-user")
+    ApiResponse<EmailResponse> creationUser(@RequestBody EmailRequest request) throws MessagingException {
+        String otp = emailService.generateOTP(request.getEmail());
+        emailService.sendOTPEmailForCreationUser(request.getEmail(),request.getUsername(), otp);
+        return ApiResponse.<EmailResponse>builder()
+                .result(EmailResponse.builder()
+                        .hashedOtp( passwordEncoder.encode(otp))
+                        .creationTime(LocalDateTime.now())
+                        .build())
+                .build();
+    }
+
 }


### PR DESCRIPTION
Thêm API để gửi email chứa OTP cho người dùng nhằm xác thực khi đăng ký tài khoản.
- Tạo endpoint POST /send-email-creation-user để gửi OTP qua email
- Sử dụng EmailService để tạo và gửi OTP
- Trả về phản hồi chứa hashed OTP và thời gian tạo

Refs feature/DKND-api-dang-ky-nguoi-dung